### PR TITLE
Add formatWithSplit class of functions to resolve issue #7.

### DIFF
--- a/src/Filesize.elm
+++ b/src/Filesize.elm
@@ -1,4 +1,7 @@
-module Filesize exposing (format, formatBase2, formatWith, defaultSettings, Settings, Units(..))
+module Filesize exposing
+    ( format, formatBase2, formatWith, defaultSettings, Settings, Units(..)
+    , formatBase2Split, formatSplit, formatWithSplit
+    )
 
 {-| This library converts a file size in bytes into a human readable string.
 
@@ -155,24 +158,27 @@ removeTrailingZeroesRegex =
 
 {-| Formats the given file size with the default settings.
 
-Convenience function for 
+Convenience function for
 
     let
-        (size,unit) = formatWithSplit settings num
+        ( size, unit ) =
+            formatWithSplit settings num
     in
-        size++" "++unit
+    size ++ " " ++ unit
 
 -}
 format : Int -> String
 format num =
     let
-        (size,unit) = formatWithSplit defaultSettings num
+        ( size, unit ) =
+            formatWithSplit defaultSettings num
     in
-        size++" "++unit
+    size ++ " " ++ unit
+
 
 {-| Formats the given file size with the default settings, returning the number and units separately, in a tuple.
 -}
-formatSplit : Int -> (String,String)
+formatSplit : Int -> ( String, String )
 formatSplit =
     formatWithSplit defaultSettings
 
@@ -183,32 +189,38 @@ formatBase2 : Int -> String
 formatBase2 =
     formatWith { defaultSettings | units = Base2 }
 
+
 {-| Formats the given file size with the binary/base2/IEC unit, returning the number and units separately, in a tuple.
 -}
-formatBase2Split : Int -> (String,String)
+formatBase2Split : Int -> ( String, String )
 formatBase2Split =
     formatWithSplit { defaultSettings | units = Base2 }
+
 
 {-| Formats the given file size with the given settings.
 -}
 formatWith : Settings -> Int -> String
 formatWith settings num =
     let
-        (size,unit) = formatWithSplit settings num
+        ( size, unit ) =
+            formatWithSplit settings num
     in
-        size++" "++unit
+    size ++ " " ++ unit
+
 
 {-| Formats the given file size with the given settings, returning the number and units separately, in a tuple.
 -}
-formatWithSplit : Settings -> Int -> (String,String)
+formatWithSplit : Settings -> Int -> ( String, String )
 formatWithSplit settings num =
     if num == 0 then
-        ("0","B")
+        ( "0", "B" )
+
     else
         let
             ( num2, negativePrefix ) =
                 if num < 0 then
                     ( num |> negate, "-" )
+
                 else
                     ( num, "" )
 
@@ -227,7 +239,7 @@ formatWithSplit settings num =
                     / toFloat unitDefinition.minimumSize
                     |> roundToDecimalPlaces settings
         in
-            (negativePrefix ++ formattedNumber, unitDefinition.abbreviation)
+        ( negativePrefix ++ formattedNumber, unitDefinition.abbreviation )
 
 
 roundToDecimalPlaces : Settings -> Float -> String
@@ -259,13 +271,15 @@ roundToDecimalPlaces settings num =
         withoutTrailingDot =
             if String.endsWith "." withoutTrailingZeroes then
                 String.dropRight 1 withoutTrailingZeroes
+
             else
                 withoutTrailingZeroes
     in
-        if settings.decimalSeparator == "." then
+    if settings.decimalSeparator == "." then
+        withoutTrailingDot
+
+    else
+        Regex.replaceAtMost 1
+            decimalSeparatorRegex
+            (\_ -> settings.decimalSeparator)
             withoutTrailingDot
-        else
-            Regex.replaceAtMost 1
-                decimalSeparatorRegex
-                (\_ -> settings.decimalSeparator)
-                withoutTrailingDot

--- a/src/Filesize.elm
+++ b/src/Filesize.elm
@@ -154,10 +154,27 @@ removeTrailingZeroesRegex =
 
 
 {-| Formats the given file size with the default settings.
+
+Convenience function for 
+
+    let
+        (size,unit) = formatWithSplit settings num
+    in
+        size++" "++unit
+
 -}
 format : Int -> String
-format =
-    formatWith defaultSettings
+format num =
+    let
+        (size,unit) = formatWithSplit defaultSettings num
+    in
+        size++" "++unit
+
+{-| Formats the given file size with the default settings, returning the number and units separately, in a tuple.
+-}
+formatSplit : Int -> (String,String)
+formatSplit =
+    formatWithSplit defaultSettings
 
 
 {-| Formats the given file size with the binary/base2/IEC unit.
@@ -166,13 +183,27 @@ formatBase2 : Int -> String
 formatBase2 =
     formatWith { defaultSettings | units = Base2 }
 
+{-| Formats the given file size with the binary/base2/IEC unit, returning the number and units separately, in a tuple.
+-}
+formatBase2Split : Int -> (String,String)
+formatBase2Split =
+    formatWithSplit { defaultSettings | units = Base2 }
 
 {-| Formats the given file size with the given settings.
 -}
 formatWith : Settings -> Int -> String
 formatWith settings num =
+    let
+        (size,unit) = formatWithSplit settings num
+    in
+        size++" "++unit
+
+{-| Formats the given file size with the given settings, returning the number and units separately, in a tuple.
+-}
+formatWithSplit : Settings -> Int -> (String,String)
+formatWithSplit settings num =
     if num == 0 then
-        "0 B"
+        ("0","B")
     else
         let
             ( num2, negativePrefix ) =
@@ -196,7 +227,7 @@ formatWith settings num =
                     / toFloat unitDefinition.minimumSize
                     |> roundToDecimalPlaces settings
         in
-            negativePrefix ++ formattedNumber ++ " " ++ unitDefinition.abbreviation
+            (negativePrefix ++ formattedNumber, unitDefinition.abbreviation)
 
 
 roundToDecimalPlaces : Settings -> Float -> String

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -9,6 +9,14 @@ import Test exposing (..)
 all : Test
 all =
     describe "Human Readable File Sizes"
+        [ string_based
+        , tuple_based
+        ]
+
+
+string_based : Test
+string_based =
+    describe "String-based cases"
         [ describe "Basic cases"
             [ test "3 B" <| \() -> Expect.equal "3 B" (format 3)
             , test "100 B" <| \() -> Expect.equal "100 B" (format 100)
@@ -195,5 +203,198 @@ all =
             , test "1 TiB" <| \() -> Expect.equal "1 TiB" (formatBase2 1099511627776)
             , test "1023.99 TiB" <| \() -> Expect.equal "1023.99 TiB" (formatBase2 1125899906842623)
             , test "1 PiB" <| \() -> Expect.equal "1 PiB" (formatBase2 1125899906842624)
+            ]
+        ]
+
+
+tuple_based : Test
+tuple_based =
+    describe "Tuple-based cases"
+        [ describe "Basic cases"
+            [ test "3 B" <| \() -> Expect.equal ( "3", "B" ) (formatSplit 3)
+            , test "100 B" <| \() -> Expect.equal ( "100", "B" ) (formatSplit 100)
+            , test "543 B" <| \() -> Expect.equal ( "543", "B" ) (formatSplit 543)
+            , test "1.33 kB" <| \() -> Expect.equal ( "1.33", "kB" ) (formatSplit 1337)
+            , test "238.67 MB" <| \() -> Expect.equal ( "238.67", "MB" ) (formatSplit 238674052)
+            ]
+        , describe "Edge cases"
+            [ test "0 B" <| \() -> Expect.equal ( "0", "B" ) (formatSplit 0)
+            , test "1 B" <| \() -> Expect.equal ( "1", "B" ) (formatSplit 1)
+            , test "999 B" <| \() -> Expect.equal ( "999", "B" ) (formatSplit 999)
+            , test "1 kB" <| \() -> Expect.equal ( "1", "kB" ) (formatSplit 1000)
+            , test "999.99 kB" <| \() -> Expect.equal ( "999.99", "kB" ) (formatSplit 999999)
+            , test "1 MB" <| \() -> Expect.equal ( "1", "MB" ) (formatSplit 1000000)
+            , test "999.99 MB" <| \() -> Expect.equal ( "999.99", "MB" ) (formatSplit 999999999)
+            , test "1 GB" <| \() -> Expect.equal ( "1", "GB" ) (formatSplit 1000000000)
+            , test "999.99 GB" <| \() -> Expect.equal ( "999.99", "GB" ) (formatSplit 999999999999)
+            , test "1 TB" <| \() -> Expect.equal ( "1", "TB" ) (formatSplit 1000000000000)
+            , test "999.99 TB" <| \() -> Expect.equal ( "999.99", "TB" ) (formatSplit 999999999999999)
+            , test "1 PB" <| \() -> Expect.equal ( "1", "PB" ) (formatSplit 1000000000000000)
+
+            -- TODO For very large file sizes, the implementation of
+            -- roundToDecimalPlaces can introduce rounding errors that lead to
+            -- different results. Therefore, for now, we test with
+            -- 999999999999999000 instead of 999999999999999999.
+            , test "999.99 PB" <| \() -> Expect.equal ( "999.99", "PB" ) (formatSplit 999999999999999000)
+            , test "1 EB" <| \() -> Expect.equal ( "1", "EB" ) (formatSplit 1000000000000000000)
+
+            -- Somewhere around this (9223350000000000000) elm-format
+            -- overwrites the Int literal with garbage, possibly due to an
+            -- integer overflow. In order to keep this file editable with
+            -- elm-format enabled, we do not use larger Ints in our tests.
+            , test "922.33 EB" <| \() -> Expect.equal ( "9.22", "EB" ) (formatSplit 9223350000000000000)
+            ]
+        , describe "Basic negative cases"
+            [ test "-3 B" <| \() -> Expect.equal ( "-3", "B" ) (formatSplit -3)
+            , test "-100 B" <| \() -> Expect.equal ( "-100", "B" ) (formatSplit -100)
+            , test "-543 B" <| \() -> Expect.equal ( "-543", "B" ) (formatSplit -543)
+            , test "-1.33 kB" <| \() -> Expect.equal ( "-1.33", "kB" ) (formatSplit -1337)
+            , test "-238.67 MB" <| \() -> Expect.equal ( "-238.67", "MB" ) (formatSplit -238674052)
+            ]
+        , describe "Negative edge cases"
+            [ test "-1 B" <| \() -> Expect.equal ( "-1", "B" ) (formatSplit -1)
+            , test "-999 B" <| \() -> Expect.equal ( "-999", "B" ) (formatSplit -999)
+            , test "-1 kB" <| \() -> Expect.equal ( "-1", "kB" ) (formatSplit -1000)
+            , test "-999.99 kB" <| \() -> Expect.equal ( "-999.99", "kB" ) (formatSplit -999999)
+            , test "-1 MB" <| \() -> Expect.equal ( "-1", "MB" ) (formatSplit -1000000)
+            , test "-999.99 MB" <| \() -> Expect.equal ( "-999.99", "MB" ) (formatSplit -999999999)
+            , test "-1 GB" <| \() -> Expect.equal ( "-1", "GB" ) (formatSplit -1000000000)
+            , test "-999.99 GB" <| \() -> Expect.equal ( "-999.99", "GB" ) (formatSplit -999999999999)
+            , test "-1 TB" <| \() -> Expect.equal ( "-1", "TB" ) (formatSplit -1000000000000)
+            , test "-999.99 TB" <| \() -> Expect.equal ( "-999.99", "TB" ) (formatSplit -999999999999999)
+            , test "-1 PB" <| \() -> Expect.equal ( "-1", "PB" ) (formatSplit -1000000000000000)
+            , test "-999.99 PB" <| \() -> Expect.equal ( "-999.99", "PB" ) (formatSplit -999999999999999000)
+            , test "-1 EB" <| \() -> Expect.equal ( "-1", "EB" ) (formatSplit -1000000000000000000)
+            , test "-922.33 EB" <| \() -> Expect.equal ( "-9.22", "EB" ) (formatSplit -9223350000000000000)
+            ]
+        , describe "Fuzzed cases"
+            [ fuzz (intRange 0 999) "Positive byte range" <|
+                \num ->
+                    Expect.true "ends with \" B\""
+                        (num |> formatSplit |> Tuple.second |> (==) "B")
+            , fuzz (intRange 0 999) "Positive byte range sign" <|
+                \num ->
+                    Expect.true "has no leading minus"
+                        (num |> formatSplit |> Tuple.first |> String.startsWith "-" |> not)
+            , fuzz (intRange -999 -1) "Negative byte range" <|
+                \num ->
+                    Expect.true "ends with \" B\""
+                        (num |> formatSplit |> Tuple.second |> (==) "B")
+            , fuzz (intRange -999 -1) "Negative byte range sign" <|
+                \num ->
+                    Expect.true "has a leading minus"
+                        (num |> formatSplit |> Tuple.first |> String.startsWith "-")
+            , fuzz (intRange 1000 999999) "Positive kB range" <|
+                \num ->
+                    Expect.true "ends with \" kB\""
+                        (num |> formatSplit |> Tuple.second |> (==) "kB")
+            , fuzz (intRange 1000 999999) "Positive kB range sign " <|
+                \num ->
+                    Expect.true "has no leading minus"
+                        (num |> formatSplit |> Tuple.first |> String.startsWith "-" |> not)
+            , fuzz (intRange -999999 -1000) "Negative kB range" <|
+                \num ->
+                    Expect.true "ends with \" kB\""
+                        (num |> formatSplit |> Tuple.second |> (==) "kB")
+            , fuzz (intRange -999999 -1000) "Negative kB range sign" <|
+                \num ->
+                    Expect.true "has a leading minus"
+                        (num |> formatSplit |> Tuple.first |> String.startsWith "-")
+            , fuzz (intRange 1000000 999999999) "Positive MB range" <|
+                \num ->
+                    Expect.true "ends with \" MB\""
+                        (num |> formatSplit |> Tuple.second |> (==) "MB")
+            , fuzz (intRange 1000000 999999999) "Positive MB range sign " <|
+                \num ->
+                    Expect.true "has no leading minus"
+                        (num |> formatSplit |> Tuple.first |> String.startsWith "-" |> not)
+            , fuzz (intRange -999999999 -1000000) "Negative MB range" <|
+                \num ->
+                    Expect.true "ends with \" MB\""
+                        (num |> formatSplit |> Tuple.second |> (==) "MB")
+            , fuzz (intRange -999999999 -1000000) "Negative MB range sign" <|
+                \num ->
+                    Expect.true "has a leading minus"
+                        (num |> formatSplit |> Tuple.first |> String.startsWith "-")
+            , fuzz (intRange 1000000000 999999999999) "Positive GB range" <|
+                \num ->
+                    Expect.true "ends with \" GB\""
+                        (num |> formatSplit |> Tuple.second |> (==) "GB")
+            , fuzz (intRange 1000000000 999999999999) "Positive GB range sign " <|
+                \num ->
+                    Expect.true "has no leading minus"
+                        (num |> formatSplit |> Tuple.first |> String.startsWith "-" |> not)
+            , fuzz (intRange -999999999999 -1000000000) "Negative GB range" <|
+                \num ->
+                    Expect.true "ends with \" GB\""
+                        (num |> formatSplit |> Tuple.second |> (==) "GB")
+            , fuzz (intRange -999999999999 -1000000000) "Negative GB range sign" <|
+                \num ->
+                    Expect.true "has a leading minus"
+                        (num |> formatSplit |> Tuple.first |> String.startsWith "-")
+            ]
+        , describe "With settings (decimalPlaces)"
+            [ test "zero decimal places" <|
+                \() ->
+                    Expect.equal
+                        ( "238", "MB" )
+                        (formatWithSplit { defaultSettings | decimalPlaces = 0 } 238674052)
+            , test "one decimal place" <|
+                \() ->
+                    Expect.equal
+                        ( "238.6", "MB" )
+                        (formatWithSplit { defaultSettings | decimalPlaces = 1 } 238674052)
+            , test "three decimal places" <|
+                \() ->
+                    Expect.equal
+                        ( "238.674", "MB" )
+                        (formatWithSplit { defaultSettings | decimalPlaces = 3 } 238674052)
+            , test "four decimal places with trailing zero" <|
+                \() ->
+                    Expect.equal
+                        ( "238.674", "MB" )
+                        (formatWithSplit { defaultSettings | decimalPlaces = 4 } 238674052)
+            , test "238.67405 MB" <|
+                \() ->
+                    Expect.equal
+                        ( "238.67405", "MB" )
+                        (formatWithSplit { defaultSettings | decimalPlaces = 5 } 238674052)
+            , test "use negative decimal places to round 1" <|
+                \() ->
+                    Expect.equal
+                        ( "230", "MB" )
+                        (formatWithSplit { defaultSettings | decimalPlaces = -1 } 238674052)
+            , test "use negative decimal places to round 2" <|
+                \() ->
+                    Expect.equal
+                        ( "200", "MB" )
+                        (formatWithSplit { defaultSettings | decimalPlaces = -2 } 238674052)
+            ]
+        , describe "With settings (decimalSeparator)"
+            [ test "use comma as decimal separator" <|
+                \() ->
+                    Expect.equal
+                        ( "238,67", "MB" )
+                        (formatWithSplit { defaultSettings | decimalSeparator = "," } 238674052)
+            ]
+        , describe "Base 2 basic cases"
+            [ test "3 B" <| \() -> Expect.equal ( "3", "B" ) (formatBase2Split 3)
+            , test "100 B" <| \() -> Expect.equal ( "100", "B" ) (formatBase2Split 100)
+            , test "543 B" <| \() -> Expect.equal ( "543", "B" ) (formatBase2Split 543)
+            , test "1.61 KiB" <| \() -> Expect.equal ( "1.61", "KiB" ) (formatBase2Split 1657)
+            , test "227.61 MiB" <| \() -> Expect.equal ( "227.61", "MiB" ) (formatBase2Split 238674052)
+            ]
+        , describe "Base 2 edge cases"
+            [ test "1 B" <| \() -> Expect.equal ( "1", "B" ) (formatBase2Split 1)
+            , test "1023 B" <| \() -> Expect.equal ( "1023", "B" ) (formatBase2Split 1023)
+            , test "1 KiB" <| \() -> Expect.equal ( "1", "KiB" ) (formatBase2Split 1024)
+            , test "1023.99 KiB" <| \() -> Expect.equal ( "1023.99", "KiB" ) (formatBase2Split 1048575)
+            , test "1 MiB" <| \() -> Expect.equal ( "1", "MiB" ) (formatBase2Split 1048576)
+            , test "1023.99 MiB" <| \() -> Expect.equal ( "1023.99", "MiB" ) (formatBase2Split 1073741823)
+            , test "1 GiB" <| \() -> Expect.equal ( "1", "GiB" ) (formatBase2Split 1073741824)
+            , test "1023.99 GiB" <| \() -> Expect.equal ( "1023.99", "GiB" ) (formatBase2Split 1099511627775)
+            , test "1 TiB" <| \() -> Expect.equal ( "1", "TiB" ) (formatBase2Split 1099511627776)
+            , test "1023.99 TiB" <| \() -> Expect.equal ( "1023.99", "TiB" ) (formatBase2Split 1125899906842623)
+            , test "1 PiB" <| \() -> Expect.equal ( "1", "PiB" ) (formatBase2Split 1125899906842624)
             ]
         ]


### PR DESCRIPTION
Let me know if all of the convenience functions this adds clutter up the documentation -- the core of this change is the `formatSplitWith` function and corresponding rewrite of formatWith.